### PR TITLE
Add: Error viewer for users

### DIFF
--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -10,6 +10,7 @@ export default async function (interaction) {
 	try {
 		await command.run(interaction);
 	} catch (e) {
+    await interaction.editReply({content: 'Произошла ошибка при выполнении команды. Обратитесь на сервер поддержки Vare.\n' + e.message})
 		if (e.code === 10062) {
 			log(interaction.commandName + ' | ' + e.message);
 		} else {


### PR DESCRIPTION
If there are any errors, the bot should not be silent. I think this change will help both users and developers